### PR TITLE
Swagger schemas

### DIFF
--- a/service/open_api.go
+++ b/service/open_api.go
@@ -178,6 +178,7 @@ func (s *Server) generateOpenAPIMap(namespaces []string) (map[string]interface{}
 		if hasSchema {
 			getNamespaceSchema := map[string]interface{}{
 				"type": "array",
+				"title": fmt.Sprintf("Get All %v", namespace),
 				"items": map[string]interface{}{
 					"type": "object",
 					"properties": map[string]interface{}{

--- a/service/open_api.go
+++ b/service/open_api.go
@@ -83,10 +83,6 @@ func (s *Server) generateOpenAPIMap(namespaces []string) (map[string]interface{}
 				},
 			},
 			"responses": map[string]interface{}{
-				"default": map[string]interface{}{
-					"description": "default response",
-					"content":     map[string]interface{}{},
-				},
 				"200": map[string]interface{}{
 					"description": "200 OK",
 					"content": map[string]interface{}{
@@ -121,14 +117,10 @@ func (s *Server) generateOpenAPIMap(namespaces []string) (map[string]interface{}
 				},
 			},
 			"responses": map[string]interface{}{
-				"default": map[string]interface{}{
-					"description": "default response",
-					"content":     map[string]interface{}{},
-				},
 				"201": map[string]interface{}{
 					"description": "201 Created",
 					"content": map[string]interface{}{
-						"application/json": map[string]interface{}{},
+						"application/json": schemaNode,
 					},
 				},
 			},
@@ -150,10 +142,6 @@ func (s *Server) generateOpenAPIMap(namespaces []string) (map[string]interface{}
 				},
 			},
 			"responses": map[string]interface{}{
-				"default": map[string]interface{}{
-					"description": "default response",
-					"content":     map[string]interface{}{},
-				},
 				"202": map[string]interface{}{
 					"description": "200 Accepted",
 					"content": map[string]interface{}{
@@ -211,10 +199,6 @@ func (s *Server) generateOpenAPIMap(namespaces []string) (map[string]interface{}
 			},
 			"parameters": []interface{}{},
 			"responses": map[string]interface{}{
-				"default": map[string]interface{}{
-					"description": "default response",
-					"content":     map[string]interface{}{},
-				},
 				"200": map[string]interface{}{
 					"description": "200 OK",
 					"content": map[string]interface{}{
@@ -231,10 +215,6 @@ func (s *Server) generateOpenAPIMap(namespaces []string) (map[string]interface{}
 			},
 			"parameters": []interface{}{},
 			"responses": map[string]interface{}{
-				"default": map[string]interface{}{
-					"description": "default response",
-					"content":     map[string]interface{}{},
-				},
 				"200": map[string]interface{}{
 					"description": "200 OK",
 					"content": map[string]interface{}{
@@ -299,10 +279,6 @@ func (s *Server) generateOpenAPIMap(namespaces []string) (map[string]interface{}
 				},
 			},
 			"responses": map[string]interface{}{
-				"default": map[string]interface{}{
-					"description": "default response",
-					"content":     map[string]interface{}{},
-				},
 				"200": map[string]interface{}{
 					"description": "200 OK",
 					"content": map[string]interface{}{
@@ -324,10 +300,6 @@ func (s *Server) generateOpenAPIMap(namespaces []string) (map[string]interface{}
 		},
 		"parameters": []interface{}{},
 		"responses": map[string]interface{}{
-			"default": map[string]interface{}{
-				"description": "default response",
-				"content":     map[string]interface{}{},
-			},
 			"200": map[string]interface{}{
 				"description": "200 OK",
 				"content": map[string]interface{}{

--- a/service/open_api.go
+++ b/service/open_api.go
@@ -176,20 +176,29 @@ func (s *Server) generateOpenAPIMap(namespaces []string) (map[string]interface{}
 		var getNamespaceSchemaNode = map[string]interface{}{}
 
 		if hasSchema {
-			getNamespaceSchemaNode = map[string]interface{}{
-				"schema": map[string]interface{}{
-					"type":  "array",
-					"items": map[string]interface{}{
-						"type": "object",
-						"properties": map[string]interface{}{
-							"key": map[string]interface{}{
-								"type": "string",
-							},
-							"value": map[string]interface{}{
-								"$ref": schemaRef,
-							},
+			getNamespaceSchema := map[string]interface{}{
+				"type": "array",
+				"items": map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"key": map[string]interface{}{
+							"type": "string",
+						},
+						"value": map[string]interface{}{
+							"$ref": schemaRef,
 						},
 					},
+				},
+			}
+
+
+			componentKey := fmt.Sprintf("get-all-%v", namespace)
+			schemasMap[componentKey] = getNamespaceSchema
+			getNamespaceSchemaRef := fmt.Sprintf("#/components/schemas/%v", componentKey)
+
+			getNamespaceSchemaNode = map[string]interface{}{
+				"schema": map[string]interface{}{
+					"$ref": getNamespaceSchemaRef,
 				},
 			}
 		}
@@ -242,25 +251,33 @@ func (s *Server) generateOpenAPIMap(namespaces []string) (map[string]interface{}
 		var searchSchemaNode = map[string]interface{}{}
 
 		if hasSchema {
-			searchSchemaNode = map[string]interface{} {
-				"schema": map[string]interface{}{
-					"type": "object",
-					"properties": map[string]interface{}{
-						"results": map[string]interface{}{
-							"type": "array",
-							"items": map[string]interface{}{
-								"type": "object",
-								"properties": map[string]interface{}{
-									"key": map[string]interface{}{
-										"type": "string",
-									},
-									"value": map[string]interface{}{
-										"$ref": schemaRef,
-									},
+			searchSchema := map[string]interface{} {
+				"title": fmt.Sprintf("Search %v", namespace),
+				"properties": map[string]interface{}{
+					"results": map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"key": map[string]interface{}{
+									"type": "string",
+								},
+								"value": map[string]interface{}{
+									"$ref": schemaRef,
 								},
 							},
 						},
 					},
+				},
+			}
+
+			componentKey := fmt.Sprintf("search-%v", namespace)
+			schemasMap[componentKey] = searchSchema
+			searchSchemaRef := fmt.Sprintf("#/components/schemas/%v", componentKey)
+
+			searchSchemaNode = map[string]interface{}{
+				"schema": map[string]interface{}{
+					"$ref": searchSchemaRef,
 				},
 			}
 		}

--- a/service/server.go
+++ b/service/server.go
@@ -294,7 +294,10 @@ func (s *Server) openAPIHandler(w http.ResponseWriter, r *http.Request) {
 
 	var namespaces []string = s.db.GetNamespaces()
 
-	rootMap := generateOpenAPIMap(namespaces)
+	rootMap, err := s.generateOpenAPIMap(namespaces)
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, err.Error())
+	}
 
 	switch r.Method {
 	case http.MethodGet:


### PR DESCRIPTION
If a namespace includes a schema, include it in the swagger definition.

This causes swagger-ui to populate the `Example Value/Schema` fields. It also causes it to provide a pre-populated sample value when performing a POST operation.

More importantly, it would allow code generation tools to create domain objects for the namespaces.

At the moment the schema is attached to the following endpoints:

GET /ns/example/
GET /ns/example/{id}
POST /ns/example/{id}
GET /search/example

⚠️NOTE: This only works for simple schemas. JSON schema and OpenAPI are syntactically very similar, but there are differences. See: https://github.com/wework/json-schema-to-openapi-schema.  I should probably create a mechanism to exclude a schema from swagger, in case we ever have to use a schema which is incompatible with swagger.

Only lightly tested so far.  Comments and suggestions welcome.